### PR TITLE
Add link to V4 primer scheme

### DIFF
--- a/_resources/2020-01-22-ncov-2019.md
+++ b/_resources/2020-01-22-ncov-2019.md
@@ -39,7 +39,7 @@ Please visit our <a href="https://community.artic.network">ARTIC community discu
         <blockquote>link: <a href="https://dx.doi.org/10.17504/protocols.io.bbmuik6w">Protocols.io</a></blockquote>
 
     <li>nCoV-2019 PrimalSeq sequencing primers</li>
-        <blockquote>link: <a href="https://github.com/artic-network/artic-ncov2019/tree/master/primer_schemes/nCoV-2019/V3">Github (version 3)</a></blockquote>
+        <blockquote>link: <a href="https://github.com/artic-network/artic-ncov2019/tree/master/primer_schemes/nCoV-2019/V4">Github (version 4)</a></blockquote>
 
 {% for doc in docs %}
     <li>{{ doc.title_text }}</li>

--- a/_resources/2020-01-22-ncov-2019.md
+++ b/_resources/2020-01-22-ncov-2019.md
@@ -13,7 +13,7 @@ category: menu
 ## Updates
 
 <ul>
- <li>24-Jun-2021: We have posted a <a href="https://community.artic.network/t/sars-cov-2-version-4-scheme-release/312">further update to the amplicon set (V4)</a>
+ <li>24-Jun-2021: We have posted a <a href="https://community.artic.network/t/sars-cov-2-version-4-scheme-release/312">further update to the amplicon set (V4)</a></li>
  <li>24-Mar-2020: We have posted <a href="/resources/ncov/ncov-amplicon-v3.pdf">an update to the amplicon set (V3)</a></li>
 </ul>
 

--- a/_resources/2020-01-22-ncov-2019.md
+++ b/_resources/2020-01-22-ncov-2019.md
@@ -13,6 +13,7 @@ category: menu
 ## Updates
 
 <ul>
+ <li>24-Jun-2021: We have posted a <a href="https://community.artic.network/t/sars-cov-2-version-4-scheme-release/312">further update to the amplicon set (V4)</a>
  <li>24-Mar-2020: We have posted <a href="/resources/ncov/ncov-amplicon-v3.pdf">an update to the amplicon set (V3)</a></li>
 </ul>
 


### PR DESCRIPTION
If you Google e.g. "ARTIC scheme covid" this page comes up top, and might suggest that V3 are the latest set of primers. This PR attempts to address that. Please reject if this change is not useful.